### PR TITLE
fix(yaml-schema.json): fix yaml validation schema

### DIFF
--- a/src/config/yaml-config.schema.json
+++ b/src/config/yaml-config.schema.json
@@ -58,7 +58,7 @@
                     "enum": [
                         "requeue",
                         "discard",
-                        "dql"
+                        "dlq"
                     ],
                     "type": "string"
                 },


### PR DESCRIPTION
Due to the fact that there was a typo in the data schema of the yaml file, the switch in the dead letter policy file did not work